### PR TITLE
Add RoleAt/MemberAt membership history

### DIFF
--- a/contracts/Drive.sol
+++ b/contracts/Drive.sol
@@ -12,6 +12,7 @@ import "./Roles.sol";
 import "./ChatGroup.sol";
 import "./ManagedProxy.sol";
 import "./IProxyResolver.sol";
+import "./MembershipHistory.sol";
 import "cross/ChainId.sol";
 
 /**
@@ -27,7 +28,7 @@ contract Drive is IDrive, ProtectedRoleGroup, IProxyResolver {
     address private immutable CHAT_IMPL = address(new ChatGroup());
     address private immutable BNS;
     bytes32 constant CHAT_REF = keccak256("CHAT_REF");
-    int256 constant VERSION = 160;
+    int256 constant VERSION = 161;
 
     Set.Data chats;
     mapping(address => address) chat_contracts;
@@ -367,6 +368,19 @@ contract Drive is IDrive, ProtectedRoleGroup, IProxyResolver {
 
     function Role(address _member) public view override(ProtectedRoleGroup, IDrive) onlyReader returns (uint256) {
         return role(_member);
+    }
+
+    function RoleAt(address _member, uint256 _timestamp)
+        public
+        view
+        override(RoleGroup, IDrive)
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return MembershipHistory.at(_member, _timestamp);
+    }
+
+    function MembershipHistoryStart() public view override(Group, IDrive) returns (uint256) {
+        return MembershipHistory.historyStart();
     }
 
     function bns() public view virtual returns (IBNS) {

--- a/contracts/DriveMember.sol
+++ b/contracts/DriveMember.sol
@@ -7,6 +7,7 @@ pragma experimental ABIEncoderV2;
 
 import "./Group.sol";
 import "./deps/SetReverseLocation.sol";
+import "./MembershipHistory.sol";
 import "cross/ChainId.sol";
 
 /**
@@ -79,7 +80,7 @@ contract DriveMember is Group {
     }
 
     function Version() external pure virtual returns (int256) {
-        return 123;
+        return 124;
     }
 
     function Type() external pure virtual returns (string memory) {
@@ -92,11 +93,18 @@ contract DriveMember is Group {
     }
 
     function AddMember(address _member) external onlyMember {
+        bool wasMember = IsMember(_member);
         members.Add(_member);
+        _ensureMembershipHistory();
+        if (!wasMember) {
+            MembershipHistory.recordJoin(_member, MEMBERSHIP_MARKER_ROLE);
+        }
         update_change_tracker();
     }
 
     function RemoveMember(address _member) external onlyMember {
+        _ensureMembershipHistory();
+        MembershipHistory.recordLeave(_member);
         members.Remove(_member);
         update_change_tracker();
     }

--- a/contracts/Group.sol
+++ b/contracts/Group.sol
@@ -10,6 +10,7 @@ import "./Roles.sol";
 import "./deps/OwnableInitializable.sol";
 import "./deps/Set.sol";
 import "./ChangeTracker.sol";
+import "./MembershipHistory.sol";
 
 /**
  * Generic Group
@@ -19,6 +20,7 @@ contract Group is Storage, OwnableInitializable, ChangeTracker {
 
     Set.Data members;
     uint256 constant DATA_SLOT = uint256(keccak256("DATA_SLOT"));
+    uint256 constant MEMBERSHIP_MARKER_ROLE = 1;
 
     struct DataKey {
         uint256 class;
@@ -42,6 +44,41 @@ contract Group is Storage, OwnableInitializable, ChangeTracker {
         update_change_tracker();
         super.initialize(arg_owner);
         members.Add(owner());
+        _ensureMembershipHistory();
+    }
+
+    /// @dev Role stored in membership history for plain Group members (overridden by RoleGroup).
+    function _membershipHistoryRole(address) internal view virtual returns (uint256) {
+        return MEMBERSHIP_MARKER_ROLE;
+    }
+
+    function _ensureMembershipHistory() internal {
+        if (!MembershipHistory.ensureStart()) {
+            return;
+        }
+        address own = owner();
+        MembershipHistory.seedOpen(own, _membershipHistoryRole(own));
+        address[] memory list = members.Members();
+        for (uint256 i = 0; i < list.length; i++) {
+            MembershipHistory.seedOpen(list[i], _membershipHistoryRole(list[i]));
+        }
+    }
+
+    function EnsureMembershipHistory() public virtual {
+        _ensureMembershipHistory();
+    }
+
+    function MembershipHistoryStart() public view virtual returns (uint256) {
+        return MembershipHistory.historyStart();
+    }
+
+    function MemberAt(address _member, uint256 _timestamp)
+        public
+        view
+        virtual
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return MembershipHistory.at(_member, _timestamp);
     }
 
     function IsMember(address _member) public view virtual returns (bool) {

--- a/contracts/IDrive.sol
+++ b/contracts/IDrive.sol
@@ -5,6 +5,8 @@
 pragma solidity >=0.7.6;
 pragma experimental ABIEncoderV2;
 
+import "./MembershipHistory.sol";
+
 interface IDrive {
     function Version() external pure returns (int256);
     function AddMember(address _member) external;
@@ -13,6 +15,11 @@ interface IDrive {
     function AddMember(address _member, uint256 role) external;
     function Swap(address payable _multisig) external;
     function Role(address _member) external view returns (uint256);
+    function RoleAt(address _member, uint256 _timestamp)
+        external
+        view
+        returns (MembershipHistory.MembershipAtResult memory);
+    function MembershipHistoryStart() external view returns (uint256);
     function Members() external returns (address[] memory);
     function RemoveSelf() external;
     function RemoveMember(address _member) external;

--- a/contracts/MembershipHistory.sol
+++ b/contracts/MembershipHistory.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: DIODE
+// Diode Contracts
+// Copyright 2021-2024 Diode
+// Licensed under the Diode License, Version 1.0
+pragma solidity ^0.7.6;
+pragma experimental ABIEncoderV2;
+
+/**
+ * Namespaced membership-interval history for upgradeable proxies.
+ *
+ * status: 0 = Unknown (pre-history / not tracking yet)
+ *         1 = None    (definitely not authorized in [validFrom, validTo))
+ *         2 = Member  (authorized with `role` in [validFrom, validTo))
+ *
+ * validTo == 0 means the interval is open-ended as of chain head.
+ */
+library MembershipHistory {
+    uint8 internal constant STATUS_UNKNOWN = 0;
+    uint8 internal constant STATUS_NONE = 1;
+    uint8 internal constant STATUS_MEMBER = 2;
+
+    bytes32 internal constant SLOT = keccak256("diode.membership.history.v1");
+
+    struct Interval {
+        uint256 role;
+        uint64 from;
+        uint64 to; // 0 = open
+    }
+
+    struct MembershipAtResult {
+        uint8 status;
+        uint256 role;
+        uint256 validFrom;
+        uint256 validTo;
+    }
+
+    struct Layout {
+        uint256 historyStart;
+        mapping(address => Interval[]) intervals;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+
+    function historyStart() internal view returns (uint256) {
+        return layout().historyStart;
+    }
+
+    /// @dev Returns true if history was just started (caller should backfill).
+    function ensureStart() internal returns (bool newlyStarted) {
+        Layout storage l = layout();
+        if (l.historyStart != 0) {
+            return false;
+        }
+        l.historyStart = block.timestamp;
+        return true;
+    }
+
+    /// @dev Seed an open interval for a current member. No-op if intervals already exist.
+    function seedOpen(address member, uint256 role) internal {
+        Layout storage l = layout();
+        Interval[] storage list = l.intervals[member];
+        if (list.length > 0) {
+            return;
+        }
+        list.push(Interval({role: role, from: uint64(l.historyStart), to: 0}));
+    }
+
+    function recordJoin(address member, uint256 role) internal {
+        Layout storage l = layout();
+        require(l.historyStart != 0, "history not started");
+        Interval[] storage list = l.intervals[member];
+        uint256 len = list.length;
+        if (len > 0 && list[len - 1].to == 0) {
+            // Already an open membership; treat as role change if needed.
+            if (list[len - 1].role != role) {
+                list[len - 1].to = uint64(block.timestamp);
+                list.push(Interval({role: role, from: uint64(block.timestamp), to: 0}));
+            }
+            return;
+        }
+        list.push(Interval({role: role, from: uint64(block.timestamp), to: 0}));
+    }
+
+    function recordLeave(address member) internal {
+        Layout storage l = layout();
+        require(l.historyStart != 0, "history not started");
+        Interval[] storage list = l.intervals[member];
+        uint256 len = list.length;
+        if (len == 0) {
+            return;
+        }
+        if (list[len - 1].to == 0) {
+            list[len - 1].to = uint64(block.timestamp);
+        }
+    }
+
+    function recordRoleChange(address member, uint256 newRole) internal {
+        Layout storage l = layout();
+        require(l.historyStart != 0, "history not started");
+        Interval[] storage list = l.intervals[member];
+        uint256 len = list.length;
+        if (len == 0 || list[len - 1].to != 0) {
+            list.push(Interval({role: newRole, from: uint64(block.timestamp), to: 0}));
+            return;
+        }
+        if (list[len - 1].role == newRole) {
+            return;
+        }
+        list[len - 1].to = uint64(block.timestamp);
+        list.push(Interval({role: newRole, from: uint64(block.timestamp), to: 0}));
+    }
+
+    function at(address member, uint256 timestamp) internal view returns (MembershipAtResult memory result) {
+        Layout storage l = layout();
+        uint256 start = l.historyStart;
+        if (start == 0 || timestamp < start) {
+            return MembershipAtResult({status: STATUS_UNKNOWN, role: 0, validFrom: 0, validTo: 0});
+        }
+
+        Interval[] storage list = l.intervals[member];
+        uint256 len = list.length;
+
+        for (uint256 i = 0; i < len; i++) {
+            Interval storage iv = list[i];
+            if (timestamp >= uint256(iv.from) && (iv.to == 0 || timestamp < uint256(iv.to))) {
+                return MembershipAtResult({
+                    status: STATUS_MEMBER,
+                    role: iv.role,
+                    validFrom: uint256(iv.from),
+                    validTo: uint256(iv.to)
+                });
+            }
+        }
+
+        // Not a member at timestamp: compute cacheable None gap.
+        uint256 gapFrom = start;
+        uint256 gapTo = 0;
+
+        for (uint256 i = 0; i < len; i++) {
+            Interval storage iv = list[i];
+            if (iv.to != 0 && uint256(iv.to) <= timestamp && uint256(iv.to) > gapFrom) {
+                gapFrom = uint256(iv.to);
+            }
+            if (uint256(iv.from) > timestamp) {
+                gapTo = uint256(iv.from);
+                break;
+            }
+        }
+
+        return MembershipAtResult({status: STATUS_NONE, role: 0, validFrom: gapFrom, validTo: gapTo});
+    }
+}

--- a/contracts/RoleGroup.sol
+++ b/contracts/RoleGroup.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.7.6;
 pragma experimental ABIEncoderV2;
 
 import "./Group.sol";
+import "./MembershipHistory.sol";
 
 /**
  * Generic Group
@@ -47,13 +48,31 @@ contract RoleGroup is Group {
         return values;
     }
 
+    function _membershipHistoryRole(address _member) internal view virtual override returns (uint256) {
+        return role(_member);
+    }
+
     function _add(address _member, uint256 _role) internal virtual {
+        // Use set membership / stored role only — do not treat owner() as wasMember,
+        // otherwise transferOwnership's post-transfer _add(newOwner, Owner) skips history.
+        bool wasMember = members.IsMember(_member);
+        uint256 oldRole = roles[_member];
         members.Add(_member);
         roles[_member] = _role;
+        _ensureMembershipHistory();
+        if (wasMember) {
+            if (oldRole != _role) {
+                MembershipHistory.recordRoleChange(_member, _role);
+            }
+        } else {
+            MembershipHistory.recordJoin(_member, _role);
+        }
         update_change_tracker();
     }
 
     function remove(address _member) internal virtual {
+        _ensureMembershipHistory();
+        MembershipHistory.recordLeave(_member);
         members.Remove(_member);
         delete roles[_member];
         update_change_tracker();
@@ -62,6 +81,15 @@ contract RoleGroup is Group {
     function role(address _member) internal view returns (uint256) {
         if (_member == owner()) return RoleType.Owner;
         return roles[_member];
+    }
+
+    function RoleAt(address _member, uint256 _timestamp)
+        public
+        view
+        virtual
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return MembershipHistory.at(_member, _timestamp);
     }
 
     function devices(address _member) internal returns (address[] memory) {

--- a/docs/specs/client-membership-history.md
+++ b/docs/specs/client-membership-history.md
@@ -1,0 +1,208 @@
+# Client Usage Spec: Membership History (`RoleAt` / `MemberAt`)
+
+This document describes how Diode Collab (ddrive) and other clients should use the on-chain membership history APIs to verify file signatures after a member or linked device has left.
+
+## Versions
+
+| Contract | Min version | APIs |
+|---|---|---|
+| `Drive` (zone) | `161` | `RoleAt`, `MembershipHistoryStart`, `EnsureMembershipHistory` |
+| `DriveMember` (identity / linked devices) | `124` | `MemberAt`, `MembershipHistoryStart`, `EnsureMembershipHistory` |
+
+Live ACL APIs (`Role`, `IsMember`, `Members`) are unchanged and still mean **authorized now**.
+
+## Problem these APIs solve
+
+A file signed while Alice was a zone member must remain verifiable after Alice leaves. The same applies to a linked device under `DriveMember` that is later removed.
+
+Do **not** call `Role(addr)` / `IsMember(addr)` for historic file verification — those reflect current state only.
+
+## Return type
+
+Both `RoleAt` and `MemberAt` return:
+
+```solidity
+struct MembershipAtResult {
+    uint8 status;      // see Status below
+    uint256 role;      // meaningful only when status == Member
+    uint256 validFrom; // inclusive unix timestamp
+    uint256 validTo;   // exclusive unix timestamp; 0 = open-ended
+}
+```
+
+### Status
+
+| Value | Name | Meaning |
+|---|---|---|
+| `0` | `Unknown` | Timestamp is before history tracking began, or history was never initialized |
+| `1` | `None` | Definitely **not** authorized in `[validFrom, validTo)` |
+| `2` | `Member` | Authorized in `[validFrom, validTo)` with `role` |
+
+### Role values
+
+**Drive / `RoleAt`** — same constants as live `Role`:
+
+| Role | Value |
+|---|---|
+| None | `0` |
+| BackupBot | `100` |
+| Reader | `200` |
+| Member | `300` |
+| Admin | `400` |
+| Owner | `500` |
+
+**DriveMember / `MemberAt`** — no zone roles; when `status == Member`, `role == 1` (membership marker).
+
+### Interval semantics
+
+- Authorization holds for timestamps `T` where `validFrom <= T < validTo`.
+- If `validTo == 0`, the interval is **open-ended** as of chain head: holds for all `T >= validFrom` until membership changes again.
+- Leave time is exclusive: at the leave timestamp, status is `None` (not `Member`).
+
+## Contract calls
+
+### Drive (zone membership)
+
+```text
+RoleAt(address member, uint256 timestamp) → MembershipAtResult
+MembershipHistoryStart() → uint256
+EnsureMembershipHistory()  // state-changing; call once after proxy upgrade if needed
+```
+
+Use `RoleAt` when verifying that an identity (or EOA) was a zone member with a sufficient role at the file’s signature time.
+
+### DriveMember (linked devices)
+
+```text
+MemberAt(address device, uint256 timestamp) → MembershipAtResult
+MembershipHistoryStart() → uint256
+EnsureMembershipHistory()
+```
+
+Use `MemberAt` when verifying that a device key was linked to an identity at the file’s signature time.
+
+### Typical verification flow
+
+```
+1. Read file signature → signer address S, file time T (unix seconds)
+2. If S is a DriveMember contract (identity):
+     a. Optionally MemberAt(deviceKey, T) on that identity if the signer is a linked device
+     b. RoleAt(identityAddress, T) on the Drive (zone)
+   If S is an EOA member of the zone:
+     RoleAt(S, T) on the Drive
+3. Interpret status (see below)
+4. Cache the returned interval for future files
+```
+
+Timestamps are **unix seconds**, matching `block.timestamp` — not block numbers. No binary search over blocks is required for membership once history is initialized.
+
+## Interpreting results
+
+### `status == Member` (2)
+
+Signer was authorized. Use `role` for permission checks (e.g. “could change common settings”).
+
+Cache key: `(driveOrIdentity, address, validFrom, validTo, role, status)`.
+
+Reuse for any later file with the same contract + address and timestamp in range.
+
+### `status == None` (1)
+
+Signer was **not** authorized in that interval. Safe to reject the signature as unauthorized for that zone/identity.
+
+Negative intervals are also cacheable (including gaps between leave and rejoin, where `validTo` is the rejoin time).
+
+### `status == Unknown` (0)
+
+History cannot answer. Causes:
+
+1. Proxy not yet upgraded to Drive ≥ 161 / DriveMember ≥ 124
+2. Upgraded but `EnsureMembershipHistory()` (or a membership mutation) has not run yet → `MembershipHistoryStart() == 0`
+3. File timestamp `< MembershipHistoryStart()` (pre-upgrade / pre-ensure period)
+
+**Client policy for Unknown:**
+
+- Prefer falling back to the legacy archive `eth_call` / block-search path **only** for `Unknown`
+- Do **not** treat `Unknown` as `None` (that would falsely reject valid pre-history signatures)
+- Do **not** treat `Unknown` as `Member`
+
+## Caching rules
+
+```
+cacheHit(T) =
+  status != Unknown
+  AND validFrom <= T
+  AND (validTo == 0 OR T < validTo)
+```
+
+| Interval kind | Cache durability |
+|---|---|
+| Closed (`validTo != 0`) | Stable forever for that range |
+| Open (`validTo == 0`) | Valid until the contract’s `change_tracker()` advances; then re-query |
+
+Recommended invalidation for open intervals:
+
+1. Store `change_tracker()` alongside the cached result
+2. On next use, if `change_tracker()` differs, discard open-ended entries for that contract and re-call `RoleAt` / `MemberAt`
+
+Batching: when verifying many files from the same signer, sort by timestamp and reuse one result across all files that fall in its interval.
+
+## Upgrade / migration checklist
+
+For **existing** zones and identities after deploying the new implementation:
+
+1. Upgrade proxy to Drive `161` / DriveMember `124` via `DriveFactory.Upgrade`
+2. Call `EnsureMembershipHistory()` once (any caller; public)
+   - Sets `MembershipHistoryStart` to `block.timestamp`
+   - Backfills open intervals for current members/devices from that start
+3. Confirm `MembershipHistoryStart() > 0`
+4. Switch verification path:
+   - `T >= MembershipHistoryStart` → use `RoleAt` / `MemberAt`
+   - `T < MembershipHistoryStart` or `status == Unknown` → legacy path
+
+For **new** contracts created after this release, history starts automatically in `initialize` — no ensure tx required.
+
+Membership mutations (`AddMember`, `RemoveMember`, role changes, etc.) also call ensure if history was not yet started.
+
+## What history does *not* cover
+
+- Membership before `MembershipHistoryStart` (always `Unknown`)
+- Hard-revoke of past signatures (compromise); leave only closes the interval going forward
+- Replacing archive nodes for other historical state — only membership-at-time is addressed here
+
+## Minimal pseudocode
+
+```elixir
+def authorized_at?(contract, address, timestamp) do
+  case role_or_member_at(contract, address, timestamp) do
+    %{status: :member, role: role, valid_from: from, valid_to: to} ->
+      cache_put(contract, address, from, to, role, :member)
+      {:ok, role}
+
+    %{status: :none, valid_from: from, valid_to: to} ->
+      cache_put(contract, address, from, to, 0, :none)
+      {:error, :not_authorized}
+
+    %{status: :unknown} ->
+      legacy_historical_role(contract, address, timestamp)
+  end
+end
+
+defp role_or_member_at(drive, address, ts) when is_drive(drive),
+  do: Contract.Drive.role_at(drive, address, ts)
+
+defp role_or_member_at(identity, device, ts) when is_drive_member(identity),
+  do: Contract.DriveMember.member_at(identity, device, ts)
+```
+
+## ABI reference
+
+```text
+RoleAt(address,uint256) → (uint8 status, uint256 role, uint256 validFrom, uint256 validTo)
+MemberAt(address,uint256) → (uint8 status, uint256 role, uint256 validFrom, uint256 validTo)
+MembershipHistoryStart() → uint256
+EnsureMembershipHistory()
+change_tracker() → uint256
+```
+
+`RoleAt` / `MemberAt` / `MembershipHistoryStart` are public view (no reader restriction) so third parties can verify signatures without already being zone members.

--- a/test/DriveFactory_test.sol
+++ b/test/DriveFactory_test.sol
@@ -48,7 +48,7 @@ contract DriveFactoryTest {
         drive.AddMember(number1, RoleType.Admin);
 
         // Factory created contract should work normally
-        Assert.equal(drive.Version(), 160, "Version() should be equal 160");
+        Assert.equal(drive.Version(), 161, "Version() should be equal 161");
         acceptanceTest(drive);
 
         // Upgrade

--- a/test/DriveMember_test.sol
+++ b/test/DriveMember_test.sol
@@ -185,7 +185,7 @@ contract DriveMemberTest is Test {
         DriveMember member = DriveMember(raw_member);
 
         Assert.equal(member.owner(), _owner, "owner should be the deployer");
-        Assert.equal(member.Version(), 123, "initial version should be 123");
+        Assert.equal(member.Version(), 124, "initial version should be 124");
 
         DriveMemberV2 newImpl = new DriveMemberV2();
 

--- a/test/MembershipHistory_test.sol
+++ b/test/MembershipHistory_test.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: DIODE
+pragma solidity ^0.7.6;
+pragma experimental ABIEncoderV2;
+
+import "./Assert.sol";
+import "./CallForwarder.sol";
+import "../contracts/BNS.sol";
+import "../contracts/Drive.sol";
+import "../contracts/DriveFactory.sol";
+import "../contracts/DriveMember.sol";
+import "../contracts/MembershipHistory.sol";
+import "../contracts/Roles.sol";
+import "./forge-std/Test.sol";
+
+contract MembershipHistoryTest is Test {
+    BNS bns;
+    DriveFactory factory;
+    Drive drive;
+    bytes32 salt32;
+    address member1;
+    address member2;
+
+    uint8 constant STATUS_UNKNOWN = 0;
+    uint8 constant STATUS_NONE = 1;
+    uint8 constant STATUS_MEMBER = 2;
+
+    function owner() public view returns (address) {
+        return address(this);
+    }
+
+    function Members() public pure returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function setUp() public {
+        vm.warp(1_700_000_000);
+        bns = new BNS();
+        factory = new DriveFactory();
+        Drive code = new Drive(address(bns));
+        salt32 = bytes32(uint256(uint160(address(code))));
+        drive = Drive(factory.Create(payable(address(this)), salt32, address(code)));
+        member1 = address(new CallForwarder(address(drive)));
+        member2 = address(new CallForwarder(address(drive)));
+    }
+
+    function testVersion() public {
+        Assert.equal(drive.Version(), int256(161), "Drive version should be 161");
+    }
+
+    function testFreshDriveHistoryStartAndOwner() public {
+        uint256 start = drive.MembershipHistoryStart();
+        Assert.greaterThan(start, uint256(0), "history start should be set on initialize");
+        Assert.equal(start, block.timestamp, "history start should equal deploy timestamp");
+
+        MembershipHistory.MembershipAtResult memory r = drive.RoleAt(address(this), block.timestamp);
+        Assert.equal(uint256(r.status), uint256(STATUS_MEMBER), "owner should be Member at now");
+        Assert.equal(r.role, RoleType.Owner, "owner role should be Owner");
+        Assert.equal(r.validFrom, start, "owner interval starts at history start");
+        Assert.equal(r.validTo, uint256(0), "owner interval should be open");
+
+        MembershipHistory.MembershipAtResult memory before = drive.RoleAt(address(this), start - 1);
+        Assert.equal(uint256(before.status), uint256(STATUS_UNKNOWN), "before history start is Unknown");
+        Assert.equal(before.validFrom, uint256(0), "Unknown has zero bounds");
+        Assert.equal(before.validTo, uint256(0), "Unknown has zero bounds");
+    }
+
+    function testJoinLeaveIntervals() public {
+        uint256 start = drive.MembershipHistoryStart();
+        vm.warp(block.timestamp + 100);
+        uint256 joinTime = block.timestamp;
+        drive.AddMember(member1, RoleType.Member);
+
+        MembershipHistory.MembershipAtResult memory mid = drive.RoleAt(member1, joinTime);
+        Assert.equal(uint256(mid.status), uint256(STATUS_MEMBER), "member at join time");
+        Assert.equal(mid.role, RoleType.Member, "role Member");
+        Assert.equal(mid.validFrom, joinTime, "validFrom is join");
+        Assert.equal(mid.validTo, uint256(0), "still open");
+
+        // Mid-membership cacheability
+        vm.warp(block.timestamp + 50);
+        MembershipHistory.MembershipAtResult memory mid2 = drive.RoleAt(member1, joinTime + 25);
+        Assert.equal(mid2.validFrom, mid.validFrom, "same validFrom while open");
+        Assert.equal(mid2.validTo, mid.validTo, "same validTo while open");
+        Assert.equal(mid2.role, mid.role, "same role while open");
+
+        vm.warp(block.timestamp + 50);
+        uint256 leaveTime = block.timestamp;
+        drive.RemoveMember(member1);
+
+        Assert.equal(drive.Role(member1), RoleType.None, "live Role after leave is None");
+        Assert.ok(!drive.IsMember(member1), "live IsMember after leave is false");
+
+        MembershipHistory.MembershipAtResult memory during = drive.RoleAt(member1, joinTime + 10);
+        Assert.equal(uint256(during.status), uint256(STATUS_MEMBER), "historic membership remains");
+        Assert.equal(during.role, RoleType.Member, "historic role");
+        Assert.equal(during.validFrom, joinTime, "closed interval from join");
+        Assert.equal(during.validTo, leaveTime, "closed interval to leave");
+
+        MembershipHistory.MembershipAtResult memory afterLeave = drive.RoleAt(member1, leaveTime);
+        Assert.equal(uint256(afterLeave.status), uint256(STATUS_NONE), "at leave time is None (exclusive end)");
+        Assert.equal(afterLeave.validFrom, leaveTime, "open-none starts at leave");
+        Assert.equal(afterLeave.validTo, uint256(0), "open-none after leave");
+
+        // Before join but after history start: None
+        MembershipHistory.MembershipAtResult memory beforeJoin = drive.RoleAt(member1, start + 1);
+        Assert.equal(uint256(beforeJoin.status), uint256(STATUS_NONE), "never-member before join is None");
+        Assert.equal(beforeJoin.validFrom, start, "none gap from history start");
+        Assert.equal(beforeJoin.validTo, joinTime, "none gap until join");
+    }
+
+    function testGapCacheAfterRejoin() public {
+        vm.warp(block.timestamp + 10);
+        uint256 join1 = block.timestamp;
+        drive.AddMember(member1, RoleType.Admin);
+
+        vm.warp(block.timestamp + 100);
+        uint256 leave1 = block.timestamp;
+        drive.RemoveMember(member1);
+
+        vm.warp(block.timestamp + 100);
+        uint256 join2 = block.timestamp;
+        drive.AddMember(member1, RoleType.Member);
+
+        MembershipHistory.MembershipAtResult memory gap = drive.RoleAt(member1, leave1 + 50);
+        Assert.equal(uint256(gap.status), uint256(STATUS_NONE), "gap is None");
+        Assert.equal(gap.validFrom, leave1, "gap from leave");
+        Assert.equal(gap.validTo, join2, "gap until rejoin is fully cacheable");
+
+        MembershipHistory.MembershipAtResult memory first = drive.RoleAt(member1, join1 + 1);
+        Assert.equal(uint256(first.status), uint256(STATUS_MEMBER), "first interval still Member");
+        Assert.equal(first.role, RoleType.Admin, "first interval Admin");
+        Assert.equal(first.validTo, leave1, "first interval closed at leave");
+
+        MembershipHistory.MembershipAtResult memory second = drive.RoleAt(member1, join2);
+        Assert.equal(uint256(second.status), uint256(STATUS_MEMBER), "second interval Member");
+        Assert.equal(second.role, RoleType.Member, "second interval Member role");
+        Assert.equal(second.validTo, uint256(0), "second interval open");
+    }
+
+    function testRoleChangeClosesAndOpens() public {
+        vm.warp(block.timestamp + 10);
+        uint256 asAdmin = block.timestamp;
+        drive.AddMember(member1, RoleType.Admin);
+
+        vm.warp(block.timestamp + 100);
+        uint256 asMember = block.timestamp;
+        drive.AddMember(member1, RoleType.Member);
+
+        MembershipHistory.MembershipAtResult memory a = drive.RoleAt(member1, asAdmin + 1);
+        Assert.equal(uint256(a.status), uint256(STATUS_MEMBER), "admin segment");
+        Assert.equal(a.role, RoleType.Admin, "Admin role");
+        Assert.equal(a.validFrom, asAdmin, "admin from");
+        Assert.equal(a.validTo, asMember, "admin until role change");
+
+        MembershipHistory.MembershipAtResult memory m = drive.RoleAt(member1, asMember);
+        Assert.equal(uint256(m.status), uint256(STATUS_MEMBER), "member segment");
+        Assert.equal(m.role, RoleType.Member, "Member role");
+        Assert.equal(m.validFrom, asMember, "member from");
+        Assert.equal(m.validTo, uint256(0), "member open");
+    }
+
+    function testUnknownVersusNone() public {
+        uint256 start = drive.MembershipHistoryStart();
+        MembershipHistory.MembershipAtResult memory unknown = drive.RoleAt(member2, start - 1);
+        Assert.equal(uint256(unknown.status), uint256(STATUS_UNKNOWN), "pre-history is Unknown");
+
+        MembershipHistory.MembershipAtResult memory none = drive.RoleAt(member2, start);
+        Assert.equal(uint256(none.status), uint256(STATUS_NONE), "never-member after start is None not Unknown");
+        Assert.equal(none.validFrom, start, "open-none from start");
+        Assert.equal(none.validTo, uint256(0), "open-none");
+    }
+
+    function testEnsureAfterSimulatedUpgrade() public {
+        // Simulate a proxy that had members before history existed by writing nothing to history
+        // and calling Ensure after warping (fresh drive already ensured at init — use a DriveMember
+        // path: create identity, then upgrade-like ensure after adding devices under controlled start).
+        // For Drive: clear is impossible; instead verify Ensure is idempotent and backfill is stable.
+        uint256 startBefore = drive.MembershipHistoryStart();
+        drive.AddMember(member1, RoleType.Reader);
+        drive.EnsureMembershipHistory();
+        Assert.equal(drive.MembershipHistoryStart(), startBefore, "Ensure is idempotent");
+
+        MembershipHistory.MembershipAtResult memory r = drive.RoleAt(member1, block.timestamp);
+        Assert.equal(uint256(r.status), uint256(STATUS_MEMBER), "member still tracked after Ensure");
+        Assert.equal(r.role, RoleType.Reader, "reader role preserved");
+    }
+
+    function testDriveMemberMemberAt() public {
+        DriveMember impl = new DriveMember();
+        bytes32 mSalt = keccak256("membership-history-member");
+        DriveMember identity = DriveMember(factory.Create(payable(address(this)), mSalt, address(impl)));
+
+        Assert.equal(identity.Version(), int256(124), "DriveMember version 124");
+        uint256 start = identity.MembershipHistoryStart();
+        Assert.greaterThan(start, uint256(0), "DriveMember history started on initialize");
+
+        MembershipHistory.MembershipAtResult memory ownerAt = identity.MemberAt(address(this), block.timestamp);
+        Assert.equal(uint256(ownerAt.status), uint256(STATUS_MEMBER), "owner is member");
+        Assert.equal(ownerAt.role, uint256(1), "membership marker role is 1");
+
+        MembershipHistory.MembershipAtResult memory pre = identity.MemberAt(address(this), start - 1);
+        Assert.equal(uint256(pre.status), uint256(STATUS_UNKNOWN), "pre-history Unknown");
+
+        address device = address(0xBEEF);
+        vm.warp(block.timestamp + 20);
+        uint256 joinTime = block.timestamp;
+        identity.AddMember(device);
+
+        MembershipHistory.MembershipAtResult memory joined = identity.MemberAt(device, joinTime);
+        Assert.equal(uint256(joined.status), uint256(STATUS_MEMBER), "device joined");
+        Assert.equal(joined.role, uint256(1), "device marker role");
+        Assert.equal(joined.validTo, uint256(0), "open membership");
+
+        vm.warp(block.timestamp + 40);
+        uint256 leaveTime = block.timestamp;
+        identity.RemoveMember(device);
+        Assert.ok(!identity.IsMember(device), "live IsMember false after remove");
+
+        MembershipHistory.MembershipAtResult memory historic = identity.MemberAt(device, joinTime + 1);
+        Assert.equal(uint256(historic.status), uint256(STATUS_MEMBER), "historic device membership");
+        Assert.equal(historic.validFrom, joinTime, "from join");
+        Assert.equal(historic.validTo, leaveTime, "to leave");
+
+        MembershipHistory.MembershipAtResult memory afterLeave2 = identity.MemberAt(device, leaveTime);
+        Assert.equal(uint256(afterLeave2.status), uint256(STATUS_NONE), "after leave None");
+        Assert.equal(afterLeave2.validFrom, leaveTime, "none from leave");
+        Assert.equal(afterLeave2.validTo, uint256(0), "open none");
+    }
+
+    function testCacheabilitySameWindow() public {
+        vm.warp(block.timestamp + 5);
+        uint256 joinTime = block.timestamp;
+        drive.AddMember(member1, RoleType.Member);
+        vm.warp(block.timestamp + 200);
+        uint256 leaveTime = block.timestamp;
+        drive.RemoveMember(member1);
+
+        MembershipHistory.MembershipAtResult memory a = drive.RoleAt(member1, joinTime + 10);
+        MembershipHistory.MembershipAtResult memory b = drive.RoleAt(member1, leaveTime - 1);
+        Assert.equal(a.validFrom, b.validFrom, "same window validFrom");
+        Assert.equal(a.validTo, b.validTo, "same window validTo");
+        Assert.equal(a.role, b.role, "same window role");
+        Assert.equal(uint256(a.status), uint256(STATUS_MEMBER), "both Member");
+    }
+
+    function testLibraryUnknownUntilEnsure() public {
+        HistoryHarness h = new HistoryHarness();
+        Assert.equal(h.start(), uint256(0), "uninitialized history start is 0");
+
+        MembershipHistory.MembershipAtResult memory u = h.at(address(0x1), block.timestamp);
+        Assert.equal(uint256(u.status), uint256(STATUS_UNKNOWN), "before ensure all queries Unknown");
+
+        vm.warp(block.timestamp + 5);
+        uint256 ensuredAt = block.timestamp;
+        h.ensureAndSeed(address(0x1), RoleType.Member);
+
+        Assert.equal(h.start(), ensuredAt, "history starts at ensure time");
+        MembershipHistory.MembershipAtResult memory pre = h.at(address(0x1), ensuredAt - 1);
+        Assert.equal(uint256(pre.status), uint256(STATUS_UNKNOWN), "pre-ensure timestamp stays Unknown");
+
+        MembershipHistory.MembershipAtResult memory post = h.at(address(0x1), ensuredAt);
+        Assert.equal(uint256(post.status), uint256(STATUS_MEMBER), "backfilled member after ensure");
+        Assert.equal(post.role, RoleType.Member, "backfilled role");
+        Assert.equal(post.validFrom, ensuredAt, "seeded from history start");
+        Assert.equal(post.validTo, uint256(0), "seeded open interval");
+    }
+
+    function testTransferOwnershipHistory() public {
+        drive.AddMember(member1, RoleType.Admin);
+        vm.warp(block.timestamp + 30);
+        uint256 transferTime = block.timestamp;
+        address prevOwner = address(this);
+        drive.transferOwnership(payable(member1));
+
+        MembershipHistory.MembershipAtResult memory prev = drive.RoleAt(prevOwner, transferTime);
+        Assert.equal(uint256(prev.status), uint256(STATUS_MEMBER), "previous owner still member as Admin");
+        Assert.equal(prev.role, RoleType.Admin, "previous owner demoted to Admin in history");
+
+        MembershipHistory.MembershipAtResult memory neu = drive.RoleAt(member1, transferTime);
+        Assert.equal(uint256(neu.status), uint256(STATUS_MEMBER), "new owner in history");
+        Assert.equal(neu.role, RoleType.Owner, "new owner recorded as Owner");
+        Assert.equal(drive.Role(member1), RoleType.Owner, "live Role is Owner");
+    }
+}
+
+/// @dev Direct library harness to simulate post-upgrade Ensure without prior history.
+contract HistoryHarness {
+    function start() external view returns (uint256) {
+        return MembershipHistory.historyStart();
+    }
+
+    function at(address member, uint256 timestamp)
+        external
+        view
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return MembershipHistory.at(member, timestamp);
+    }
+
+    function ensureAndSeed(address member, uint256 role) external {
+        require(MembershipHistory.ensureStart(), "already started");
+        MembershipHistory.seedOpen(member, role);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds proxy-safe membership interval history (`MembershipHistory`) with `RoleAt` (Drive) and `MemberAt` (DriveMember) returning cacheable `(status, role, validFrom, validTo)` tuples
- Distinguishes `Unknown` (pre-upgrade / before `MembershipHistoryStart`) from definitive `None` vs `Member`
- Includes client usage spec and Foundry coverage; bumps Drive to v161 and DriveMember to v124

## Test plan
- [x] `forge test --match-contract MembershipHistoryTest`
- [x] `forge test --match-contract DriveTest`
- [x] `forge test --match-contract DriveMemberTest`
- [ ] Confirm upgraded proxies call `EnsureMembershipHistory()` once after deploy
- [ ] ddrive can switch historic role lookup to `RoleAt`/`MemberAt` for `T >= MembershipHistoryStart`


Made with [Cursor](https://cursor.com)