### PR TITLE
Reader-gate membership history APIs on Oasis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ format:
 test:
 	forge test -vvv
 
+.PHONY: test-oasis
+test-oasis:
+	FOUNDRY_PROFILE=oasis forge test --match-test testHistoryApisReaderGate -vvv
+
 .PHONY: test-gas
 test-gas:
 	forge test --match-contract DiodeRegistryLightGas -vv

--- a/contracts/ChatGroup.sol
+++ b/contracts/ChatGroup.sol
@@ -21,16 +21,16 @@ contract ChatGroup is ProtectedRoleGroup {
 
     function requireReader(address _member) internal view virtual override {
         if (ChainId.THIS == ChainId.OASIS) {
-            require(_member == address(zone()) || role(_member) >= RoleType.None, "Read access not allowed");
+            require(_member == address(zone()) || role(_member) > RoleType.None, "Read access not allowed");
         }
     }
 
     function IsReader(address _member) external view returns (bool) {
         require(
-            msg.sender == address(zone()) || role(msg.sender) >= RoleType.None,
+            msg.sender == address(zone()) || role(msg.sender) > RoleType.None,
             "Only members and zone admins can call this"
         );
-        return _member == address(zone()) || role(_member) >= RoleType.None;
+        return _member == address(zone()) || role(_member) > RoleType.None;
     }
 
     function Version() external view virtual returns (int256) {
@@ -86,7 +86,7 @@ contract ChatGroup is ProtectedRoleGroup {
 
     function InfoAggregateV1(uint256 max_size) external returns (Info memory) {
         address _zone = address(zone());
-        if (_zone == address(0) || msg.sender == _zone || role(msg.sender) >= RoleType.None) {
+        if (_zone == address(0) || msg.sender == _zone || role(msg.sender) > RoleType.None) {
             MemberInfo[] memory _member_infos = MemberRoles(Members(0, max_size));
             return Info({
                 chat: address(this),

--- a/contracts/Drive.sol
+++ b/contracts/Drive.sol
@@ -28,7 +28,7 @@ contract Drive is IDrive, ProtectedRoleGroup, IProxyResolver {
     address private immutable CHAT_IMPL = address(new ChatGroup());
     address private immutable BNS;
     bytes32 constant CHAT_REF = keccak256("CHAT_REF");
-    int256 constant VERSION = 161;
+    int256 constant VERSION = 162;
 
     Set.Data chats;
     mapping(address => address) chat_contracts;
@@ -373,14 +373,15 @@ contract Drive is IDrive, ProtectedRoleGroup, IProxyResolver {
     function RoleAt(address _member, uint256 _timestamp)
         public
         view
-        override(RoleGroup, IDrive)
+        override(ProtectedRoleGroup, IDrive)
+        onlyReader
         returns (MembershipHistory.MembershipAtResult memory)
     {
-        return MembershipHistory.at(_member, _timestamp);
+        return super.RoleAt(_member, _timestamp);
     }
 
-    function MembershipHistoryStart() public view override(Group, IDrive) returns (uint256) {
-        return MembershipHistory.historyStart();
+    function MembershipHistoryStart() public view override(ProtectedRoleGroup, IDrive) onlyReader returns (uint256) {
+        return super.MembershipHistoryStart();
     }
 
     function bns() public view virtual returns (IBNS) {

--- a/contracts/Drive.sol
+++ b/contracts/Drive.sol
@@ -360,8 +360,8 @@ contract Drive is IDrive, ProtectedRoleGroup, IProxyResolver {
         }
     }
 
-    // Resolve interface collision: both Group and IDrive declare Members and Role as public/external.
-    // We provide explicit overrides and expose them with the same visibility as IDrive.
+    // IDrive + ProtectedRoleGroup both declare Members/Role/RoleAt/MembershipHistoryStart.
+    // RoleAt/MembershipHistoryStart omit onlyReader here — ProtectedRoleGroup applies it once via super.
     function Members() public override(ProtectedRoleGroup, IDrive) onlyReader returns (address[] memory) {
         return super.Members();
     }
@@ -374,13 +374,12 @@ contract Drive is IDrive, ProtectedRoleGroup, IProxyResolver {
         public
         view
         override(ProtectedRoleGroup, IDrive)
-        onlyReader
         returns (MembershipHistory.MembershipAtResult memory)
     {
         return super.RoleAt(_member, _timestamp);
     }
 
-    function MembershipHistoryStart() public view override(ProtectedRoleGroup, IDrive) onlyReader returns (uint256) {
+    function MembershipHistoryStart() public view override(ProtectedRoleGroup, IDrive) returns (uint256) {
         return super.MembershipHistoryStart();
     }
 

--- a/contracts/DriveMember.sol
+++ b/contracts/DriveMember.sol
@@ -80,7 +80,7 @@ contract DriveMember is Group {
     }
 
     function Version() external pure virtual returns (int256) {
-        return 124;
+        return 125;
     }
 
     function Type() external pure virtual returns (string memory) {
@@ -162,6 +162,21 @@ contract DriveMember is Group {
 
     function IsMember(address _member) public view override returns (bool) {
         return owner() == _member || super.IsMember(_member);
+    }
+
+    /// @dev Reader-gated like other Oasis reads (`Nonce`, `Drive`, …). Unrestricted on non-Oasis chains.
+    function MemberAt(address _member, uint256 _timestamp)
+        public
+        view
+        override
+        onlyReader
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return super.MemberAt(_member, _timestamp);
+    }
+
+    function MembershipHistoryStart() public view override onlyReader returns (uint256) {
+        return super.MembershipHistoryStart();
     }
 
     function SubmitTransaction(address dst, bytes memory data) public onlyMember {

--- a/contracts/DriveMember.sol
+++ b/contracts/DriveMember.sol
@@ -164,7 +164,6 @@ contract DriveMember is Group {
         return owner() == _member || super.IsMember(_member);
     }
 
-    /// @dev Reader-gated like other Oasis reads (`Nonce`, `Drive`, …). Unrestricted on non-Oasis chains.
     function MemberAt(address _member, uint256 _timestamp)
         public
         view

--- a/contracts/ProtectedRoleGroup.sol
+++ b/contracts/ProtectedRoleGroup.sol
@@ -19,9 +19,11 @@ contract ProtectedRoleGroup is RoleGroup {
         _;
     }
 
+    // Oasis: only readers (role > None) and the contract itself.
+    // Other chains: unrestricted (ChainId.THIS != OASIS).
     function requireReader(address _member) internal view virtual {
         if (ChainId.THIS == ChainId.OASIS) {
-            require(_member == address(this) || role(_member) >= RoleType.None, "Read access not allowed");
+            require(_member == address(this) || role(_member) > RoleType.None, "Read access not allowed");
         }
     }
 
@@ -51,6 +53,34 @@ contract ProtectedRoleGroup is RoleGroup {
 
     function Role(address _member) external view virtual override onlyReader returns (uint256) {
         return role(_member);
+    }
+
+    /// @dev Same reader gate as `Role` — historical membership is still private on Oasis.
+    function RoleAt(address _member, uint256 _timestamp)
+        public
+        view
+        virtual
+        override
+        onlyReader
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return super.RoleAt(_member, _timestamp);
+    }
+
+    /// @dev Same reader gate as `IsMember` for plain Group history under ProtectedRoleGroup.
+    function MemberAt(address _member, uint256 _timestamp)
+        public
+        view
+        virtual
+        override
+        onlyReader
+        returns (MembershipHistory.MembershipAtResult memory)
+    {
+        return super.MemberAt(_member, _timestamp);
+    }
+
+    function MembershipHistoryStart() public view virtual override onlyReader returns (uint256) {
+        return super.MembershipHistoryStart();
     }
 
     function Members() public virtual override onlyReader returns (address[] memory) {

--- a/contracts/ProtectedRoleGroup.sol
+++ b/contracts/ProtectedRoleGroup.sol
@@ -19,8 +19,7 @@ contract ProtectedRoleGroup is RoleGroup {
         _;
     }
 
-    // Oasis: only readers (role > None) and the contract itself.
-    // Other chains: unrestricted (ChainId.THIS != OASIS).
+    // Oasis: role > None (None==0 so `>= None` would always pass). Other chains: no-op.
     function requireReader(address _member) internal view virtual {
         if (ChainId.THIS == ChainId.OASIS) {
             require(_member == address(this) || role(_member) > RoleType.None, "Read access not allowed");
@@ -55,7 +54,6 @@ contract ProtectedRoleGroup is RoleGroup {
         return role(_member);
     }
 
-    /// @dev Same reader gate as `Role` — historical membership is still private on Oasis.
     function RoleAt(address _member, uint256 _timestamp)
         public
         view
@@ -67,7 +65,6 @@ contract ProtectedRoleGroup is RoleGroup {
         return super.RoleAt(_member, _timestamp);
     }
 
-    /// @dev Same reader gate as `IsMember` for plain Group history under ProtectedRoleGroup.
     function MemberAt(address _member, uint256 _timestamp)
         public
         view

--- a/docs/specs/client-membership-history.md
+++ b/docs/specs/client-membership-history.md
@@ -6,8 +6,8 @@ This document describes how Diode Collab (ddrive) and other clients should use t
 
 | Contract | Min version | APIs |
 |---|---|---|
-| `Drive` (zone) | `161` | `RoleAt`, `MembershipHistoryStart`, `EnsureMembershipHistory` |
-| `DriveMember` (identity / linked devices) | `124` | `MemberAt`, `MembershipHistoryStart`, `EnsureMembershipHistory` |
+| `Drive` (zone) | `162` | `RoleAt`, `MembershipHistoryStart`, `EnsureMembershipHistory` |
+| `DriveMember` (identity / linked devices) | `125` | `MemberAt`, `MembershipHistoryStart`, `EnsureMembershipHistory` |
 
 Live ACL APIs (`Role`, `IsMember`, `Members`) are unchanged and still mean **authorized now**.
 
@@ -59,6 +59,35 @@ struct MembershipAtResult {
 - If `validTo == 0`, the interval is **open-ended** as of chain head: holds for all `T >= validFrom` until membership changes again.
 - Leave time is exclusive: at the leave timestamp, status is `None` (not `Member`).
 
+## Access control (Oasis vs other chains)
+
+History views use the same reader gate as live read APIs (`Role`, `IsMember`, …):
+
+| API | Gate |
+|---|---|
+| `RoleAt` | `ProtectedRoleGroup.onlyReader` (zone) |
+| `MemberAt` | `onlyReader` on `DriveMember` |
+| `MembershipHistoryStart` | same as above per contract |
+| `EnsureMembershipHistory` | **public** (any caller; needed after proxy upgrade) |
+
+### Non-Oasis (Diode, Moonbeam, Base, …)
+
+`requireReader` is a no-op. Anyone can call view history APIs. Third-party signature verification can query freely.
+
+### Oasis (`ChainId.THIS == OASIS`)
+
+Reads are **private**: the caller must be an authorized reader, identical to `Role` / other protected views.
+
+**Drive / `ProtectedRoleGroup`:** caller must be `address(this)` or have `role(caller) > RoleType.None` (BackupBot and above). `Drive` additionally allows zone whitelist and registered chat contracts before that check.
+
+**DriveMember:** caller must be `address(this)`, a member (or owner), an additional-drive address, or on the identity whitelist.
+
+Implications for clients on Oasis:
+
+- Signature verification must run as a reader (zone member / identity member / whitelisted verifier), not as an arbitrary third-party EOA.
+- After a member leaves, that address can no longer call `RoleAt` / `MemberAt` — verify and cache intervals **while** the verifier still has read access, or use a long-lived reader/whitelist account for verification.
+- On Oasis, do not assume public RPC eth_call as a stranger will succeed for membership history.
+
 ## Contract calls
 
 ### Drive (zone membership)
@@ -96,6 +125,8 @@ Use `MemberAt` when verifying that a device key was linked to an identity at the
 
 Timestamps are **unix seconds**, matching `block.timestamp` — not block numbers. No binary search over blocks is required for membership once history is initialized.
 
+On Oasis, steps 2a/2b must be submitted with a reader identity (see Access control).
+
 ## Interpreting results
 
 ### `status == Member` (2)
@@ -116,7 +147,7 @@ Negative intervals are also cacheable (including gaps between leave and rejoin, 
 
 History cannot answer. Causes:
 
-1. Proxy not yet upgraded to Drive ≥ 161 / DriveMember ≥ 124
+1. Proxy not yet upgraded to Drive ≥ 162 / DriveMember ≥ 125
 2. Upgraded but `EnsureMembershipHistory()` (or a membership mutation) has not run yet → `MembershipHistoryStart() == 0`
 3. File timestamp `< MembershipHistoryStart()` (pre-upgrade / pre-ensure period)
 
@@ -151,11 +182,11 @@ Batching: when verifying many files from the same signer, sort by timestamp and 
 
 For **existing** zones and identities after deploying the new implementation:
 
-1. Upgrade proxy to Drive `161` / DriveMember `124` via `DriveFactory.Upgrade`
+1. Upgrade proxy to Drive `162` / DriveMember `125` via `DriveFactory.Upgrade`
 2. Call `EnsureMembershipHistory()` once (any caller; public)
    - Sets `MembershipHistoryStart` to `block.timestamp`
    - Backfills open intervals for current members/devices from that start
-3. Confirm `MembershipHistoryStart() > 0`
+3. Confirm `MembershipHistoryStart() > 0` (caller must be a reader on Oasis)
 4. Switch verification path:
    - `T >= MembershipHistoryStart` → use `RoleAt` / `MemberAt`
    - `T < MembershipHistoryStart` or `status == Unknown` → legacy path
@@ -205,4 +236,4 @@ EnsureMembershipHistory()
 change_tracker() → uint256
 ```
 
-`RoleAt` / `MemberAt` / `MembershipHistoryStart` are public view (no reader restriction) so third parties can verify signatures without already being zone members.
+View history APIs are reader-gated via `onlyReader` on Oasis (same family as `Role` / live membership reads) and unrestricted on other chains. `EnsureMembershipHistory` remains callable by anyone.

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,10 +4,8 @@ optimizer = true
 optimizer_runs = 200
 remappings = ["cross=lib/diode"]
 
-# Compile with Oasis ChainId.THIS so onlyReader is enforced (see ProtectedRoleGroup).
+# Oasis ChainId.THIS so onlyReader is enforced (inherits optimizer settings from default).
 [profile.oasis]
-optimizer = true
-optimizer_runs = 200
 remappings = ["cross=lib/oasis"]
 
 [profile.lint]

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,12 @@ optimizer = true
 optimizer_runs = 200
 remappings = ["cross=lib/diode"]
 
+# Compile with Oasis ChainId.THIS so onlyReader is enforced (see ProtectedRoleGroup).
+[profile.oasis]
+optimizer = true
+optimizer_runs = 200
+remappings = ["cross=lib/oasis"]
+
 [profile.lint]
 # Note: To exclude test/forge-std/**, run: forge lint contracts test/*.sol
 
- 

--- a/test/DriveFactory_test.sol
+++ b/test/DriveFactory_test.sol
@@ -48,7 +48,7 @@ contract DriveFactoryTest {
         drive.AddMember(number1, RoleType.Admin);
 
         // Factory created contract should work normally
-        Assert.equal(drive.Version(), 161, "Version() should be equal 161");
+        Assert.equal(drive.Version(), 162, "Version() should be equal 162");
         acceptanceTest(drive);
 
         // Upgrade

--- a/test/DriveMember_test.sol
+++ b/test/DriveMember_test.sol
@@ -185,7 +185,7 @@ contract DriveMemberTest is Test {
         DriveMember member = DriveMember(raw_member);
 
         Assert.equal(member.owner(), _owner, "owner should be the deployer");
-        Assert.equal(member.Version(), 124, "initial version should be 124");
+        Assert.equal(member.Version(), 125, "initial version should be 125");
 
         DriveMemberV2 newImpl = new DriveMemberV2();
 

--- a/test/MembershipHistory_test.sol
+++ b/test/MembershipHistory_test.sol
@@ -104,6 +104,8 @@ contract MembershipHistoryTest is Test {
 
         MembershipHistory.MembershipAtResult memory beforeJoin = drive.RoleAt(member1, start + 1);
         Assert.equal(uint256(beforeJoin.status), uint256(STATUS_NONE), "before first join is None after history start");
+        Assert.equal(beforeJoin.validFrom, start, "none gap from history start");
+        Assert.equal(beforeJoin.validTo, joinTime, "none gap until join");
     }
 
     function testRejoinGaps() public {
@@ -286,7 +288,6 @@ contract MembershipHistoryTest is Test {
         identity.AddMember(device);
 
         if (ChainId.THIS == ChainId.OASIS) {
-            // Drive: stranger cannot read history or live Role
             vm.prank(stranger);
             vm.expectRevert();
             drive.RoleAt(member1, block.timestamp);
@@ -299,7 +300,6 @@ contract MembershipHistoryTest is Test {
             vm.expectRevert();
             drive.Role(member1);
 
-            // Drive: reader role can read history
             vm.prank(member1);
             MembershipHistory.MembershipAtResult memory asReader = drive.RoleAt(member1, block.timestamp);
             Assert.equal(uint256(asReader.status), uint256(STATUS_MEMBER), "reader can RoleAt");
@@ -307,17 +307,15 @@ contract MembershipHistoryTest is Test {
             vm.prank(member1);
             Assert.greaterThan(drive.MembershipHistoryStart(), uint256(0), "reader can MembershipHistoryStart");
 
-            // Drive: whitelist grants history read without a zone role
             drive.AddWhitelist(stranger);
             vm.prank(stranger);
             MembershipHistory.MembershipAtResult memory asWl = drive.RoleAt(member1, block.timestamp);
             Assert.equal(uint256(asWl.status), uint256(STATUS_MEMBER), "whitelist can RoleAt");
 
-            // Ensure stays public (state change), not reader-gated
+            // Ensure stays public after upgrade
             vm.prank(address(0xE1150));
             drive.EnsureMembershipHistory();
 
-            // DriveMember: stranger blocked; owner/member allowed
             vm.prank(stranger);
             vm.expectRevert();
             identity.MemberAt(device, block.timestamp);
@@ -329,13 +327,11 @@ contract MembershipHistoryTest is Test {
             MembershipHistory.MembershipAtResult memory ownerRead = identity.MemberAt(device, block.timestamp);
             Assert.equal(uint256(ownerRead.status), uint256(STATUS_MEMBER), "owner can MemberAt");
 
-            // After leave, former member loses live read on Drive history
             drive.RemoveMember(member1);
             vm.prank(member1);
             vm.expectRevert();
             drive.RoleAt(member1, block.timestamp);
         } else {
-            // Non-Oasis: open read for any caller
             vm.prank(stranger);
             MembershipHistory.MembershipAtResult memory open = drive.RoleAt(member1, block.timestamp);
             Assert.equal(uint256(open.status), uint256(STATUS_MEMBER), "non-oasis stranger can RoleAt");

--- a/test/MembershipHistory_test.sol
+++ b/test/MembershipHistory_test.sol
@@ -11,6 +11,7 @@ import "../contracts/DriveMember.sol";
 import "../contracts/MembershipHistory.sol";
 import "../contracts/Roles.sol";
 import "./forge-std/Test.sol";
+import "cross/ChainId.sol";
 
 contract MembershipHistoryTest is Test {
     BNS bns;
@@ -44,7 +45,7 @@ contract MembershipHistoryTest is Test {
     }
 
     function testVersion() public {
-        Assert.equal(drive.Version(), int256(161), "Drive version should be 161");
+        Assert.equal(drive.Version(), int256(162), "Drive version should be 162");
     }
 
     function testFreshDriveHistoryStartAndOwner() public {
@@ -98,85 +99,75 @@ contract MembershipHistoryTest is Test {
 
         MembershipHistory.MembershipAtResult memory afterLeave = drive.RoleAt(member1, leaveTime);
         Assert.equal(uint256(afterLeave.status), uint256(STATUS_NONE), "at leave time is None (exclusive end)");
-        Assert.equal(afterLeave.validFrom, leaveTime, "open-none starts at leave");
-        Assert.equal(afterLeave.validTo, uint256(0), "open-none after leave");
+        Assert.equal(afterLeave.validFrom, leaveTime, "None starts at leave");
+        Assert.equal(afterLeave.validTo, uint256(0), "None is open until rejoin");
 
-        // Before join but after history start: None
         MembershipHistory.MembershipAtResult memory beforeJoin = drive.RoleAt(member1, start + 1);
-        Assert.equal(uint256(beforeJoin.status), uint256(STATUS_NONE), "never-member before join is None");
-        Assert.equal(beforeJoin.validFrom, start, "none gap from history start");
-        Assert.equal(beforeJoin.validTo, joinTime, "none gap until join");
+        Assert.equal(uint256(beforeJoin.status), uint256(STATUS_NONE), "before first join is None after history start");
     }
 
-    function testGapCacheAfterRejoin() public {
+    function testRejoinGaps() public {
         vm.warp(block.timestamp + 10);
         uint256 join1 = block.timestamp;
-        drive.AddMember(member1, RoleType.Admin);
-
-        vm.warp(block.timestamp + 100);
+        drive.AddMember(member1, RoleType.Member);
+        vm.warp(block.timestamp + 30);
         uint256 leave1 = block.timestamp;
         drive.RemoveMember(member1);
-
         vm.warp(block.timestamp + 100);
         uint256 join2 = block.timestamp;
-        drive.AddMember(member1, RoleType.Member);
+        drive.AddMember(member1, RoleType.Admin);
 
         MembershipHistory.MembershipAtResult memory gap = drive.RoleAt(member1, leave1 + 50);
-        Assert.equal(uint256(gap.status), uint256(STATUS_NONE), "gap is None");
+        Assert.equal(uint256(gap.status), uint256(STATUS_NONE), "gap between leave and rejoin");
         Assert.equal(gap.validFrom, leave1, "gap from leave");
-        Assert.equal(gap.validTo, join2, "gap until rejoin is fully cacheable");
+        Assert.equal(gap.validTo, join2, "gap ends at rejoin");
 
         MembershipHistory.MembershipAtResult memory first = drive.RoleAt(member1, join1 + 1);
-        Assert.equal(uint256(first.status), uint256(STATUS_MEMBER), "first interval still Member");
-        Assert.equal(first.role, RoleType.Admin, "first interval Admin");
-        Assert.equal(first.validTo, leave1, "first interval closed at leave");
+        Assert.equal(uint256(first.status), uint256(STATUS_MEMBER), "first membership interval");
+        Assert.equal(first.role, RoleType.Member, "first was Member");
+        Assert.equal(first.validTo, leave1, "first closed at leave");
 
         MembershipHistory.MembershipAtResult memory second = drive.RoleAt(member1, join2);
-        Assert.equal(uint256(second.status), uint256(STATUS_MEMBER), "second interval Member");
-        Assert.equal(second.role, RoleType.Member, "second interval Member role");
-        Assert.equal(second.validTo, uint256(0), "second interval open");
+        Assert.equal(uint256(second.status), uint256(STATUS_MEMBER), "second membership");
+        Assert.equal(second.role, RoleType.Admin, "rejoin as Admin");
+        Assert.equal(second.validFrom, join2, "from rejoin");
+        Assert.equal(second.validTo, uint256(0), "second open");
     }
 
-    function testRoleChangeClosesAndOpens() public {
-        vm.warp(block.timestamp + 10);
+    function testRoleChangeInterval() public {
+        vm.warp(block.timestamp + 5);
+        uint256 asMember = block.timestamp;
+        drive.AddMember(member1, RoleType.Member);
+        vm.warp(block.timestamp + 40);
         uint256 asAdmin = block.timestamp;
         drive.AddMember(member1, RoleType.Admin);
 
-        vm.warp(block.timestamp + 100);
-        uint256 asMember = block.timestamp;
-        drive.AddMember(member1, RoleType.Member);
-
         MembershipHistory.MembershipAtResult memory a = drive.RoleAt(member1, asAdmin + 1);
-        Assert.equal(uint256(a.status), uint256(STATUS_MEMBER), "admin segment");
-        Assert.equal(a.role, RoleType.Admin, "Admin role");
-        Assert.equal(a.validFrom, asAdmin, "admin from");
-        Assert.equal(a.validTo, asMember, "admin until role change");
+        Assert.equal(uint256(a.status), uint256(STATUS_MEMBER), "admin after change");
+        Assert.equal(a.role, RoleType.Admin, "role is Admin");
+        Assert.equal(a.validFrom, asAdmin, "role change starts new interval");
 
         MembershipHistory.MembershipAtResult memory m = drive.RoleAt(member1, asMember);
-        Assert.equal(uint256(m.status), uint256(STATUS_MEMBER), "member segment");
-        Assert.equal(m.role, RoleType.Member, "Member role");
-        Assert.equal(m.validFrom, asMember, "member from");
-        Assert.equal(m.validTo, uint256(0), "member open");
+        Assert.equal(uint256(m.status), uint256(STATUS_MEMBER), "prior member interval");
+        Assert.equal(m.role, RoleType.Member, "prior role Member");
+        Assert.equal(m.validFrom, asMember, "from add");
+        Assert.equal(m.validTo, asAdmin, "closed at role change");
     }
 
-    function testUnknownVersusNone() public {
+    function testUnknownAddressIsNoneAfterStart() public {
         uint256 start = drive.MembershipHistoryStart();
         MembershipHistory.MembershipAtResult memory unknown = drive.RoleAt(member2, start - 1);
-        Assert.equal(uint256(unknown.status), uint256(STATUS_UNKNOWN), "pre-history is Unknown");
+        Assert.equal(uint256(unknown.status), uint256(STATUS_UNKNOWN), "pre-start any address Unknown");
 
         MembershipHistory.MembershipAtResult memory none = drive.RoleAt(member2, start);
-        Assert.equal(uint256(none.status), uint256(STATUS_NONE), "never-member after start is None not Unknown");
-        Assert.equal(none.validFrom, start, "open-none from start");
-        Assert.equal(none.validTo, uint256(0), "open-none");
+        Assert.equal(uint256(none.status), uint256(STATUS_NONE), "never joined is None after start");
+        Assert.equal(none.validFrom, start, "from history start");
+        Assert.equal(none.validTo, uint256(0), "open never-joined");
     }
 
-    function testEnsureAfterSimulatedUpgrade() public {
-        // Simulate a proxy that had members before history existed by writing nothing to history
-        // and calling Ensure after warping (fresh drive already ensured at init — use a DriveMember
-        // path: create identity, then upgrade-like ensure after adding devices under controlled start).
-        // For Drive: clear is impossible; instead verify Ensure is idempotent and backfill is stable.
-        uint256 startBefore = drive.MembershipHistoryStart();
+    function testEnsureIdempotentPreservesHistory() public {
         drive.AddMember(member1, RoleType.Reader);
+        uint256 startBefore = drive.MembershipHistoryStart();
         drive.EnsureMembershipHistory();
         Assert.equal(drive.MembershipHistoryStart(), startBefore, "Ensure is idempotent");
 
@@ -190,7 +181,7 @@ contract MembershipHistoryTest is Test {
         bytes32 mSalt = keccak256("membership-history-member");
         DriveMember identity = DriveMember(factory.Create(payable(address(this)), mSalt, address(impl)));
 
-        Assert.equal(identity.Version(), int256(124), "DriveMember version 124");
+        Assert.equal(identity.Version(), int256(125), "DriveMember version 125");
         uint256 start = identity.MembershipHistoryStart();
         Assert.greaterThan(start, uint256(0), "DriveMember history started on initialize");
 
@@ -280,6 +271,85 @@ contract MembershipHistoryTest is Test {
         Assert.equal(uint256(neu.status), uint256(STATUS_MEMBER), "new owner in history");
         Assert.equal(neu.role, RoleType.Owner, "new owner recorded as Owner");
         Assert.equal(drive.Role(member1), RoleType.Owner, "live Role is Owner");
+    }
+
+    /// @dev History views share onlyReader with Role. On Oasis strangers are blocked;
+    /// on other chains (default foundry remap) requireReader is a no-op.
+    function testHistoryApisReaderGate() public {
+        address stranger = address(0xB0B5);
+        drive.AddMember(member1, RoleType.Reader);
+
+        DriveMember impl = new DriveMember();
+        bytes32 mSalt = keccak256("oasis-reader-gate-member");
+        DriveMember identity = DriveMember(factory.Create(payable(address(this)), mSalt, address(impl)));
+        address device = address(0xD0D0);
+        identity.AddMember(device);
+
+        if (ChainId.THIS == ChainId.OASIS) {
+            // Drive: stranger cannot read history or live Role
+            vm.prank(stranger);
+            vm.expectRevert();
+            drive.RoleAt(member1, block.timestamp);
+
+            vm.prank(stranger);
+            vm.expectRevert();
+            drive.MembershipHistoryStart();
+
+            vm.prank(stranger);
+            vm.expectRevert();
+            drive.Role(member1);
+
+            // Drive: reader role can read history
+            vm.prank(member1);
+            MembershipHistory.MembershipAtResult memory asReader = drive.RoleAt(member1, block.timestamp);
+            Assert.equal(uint256(asReader.status), uint256(STATUS_MEMBER), "reader can RoleAt");
+
+            vm.prank(member1);
+            Assert.greaterThan(drive.MembershipHistoryStart(), uint256(0), "reader can MembershipHistoryStart");
+
+            // Drive: whitelist grants history read without a zone role
+            drive.AddWhitelist(stranger);
+            vm.prank(stranger);
+            MembershipHistory.MembershipAtResult memory asWl = drive.RoleAt(member1, block.timestamp);
+            Assert.equal(uint256(asWl.status), uint256(STATUS_MEMBER), "whitelist can RoleAt");
+
+            // Ensure stays public (state change), not reader-gated
+            vm.prank(address(0xE1150));
+            drive.EnsureMembershipHistory();
+
+            // DriveMember: stranger blocked; owner/member allowed
+            vm.prank(stranger);
+            vm.expectRevert();
+            identity.MemberAt(device, block.timestamp);
+
+            vm.prank(stranger);
+            vm.expectRevert();
+            identity.MembershipHistoryStart();
+
+            MembershipHistory.MembershipAtResult memory ownerRead = identity.MemberAt(device, block.timestamp);
+            Assert.equal(uint256(ownerRead.status), uint256(STATUS_MEMBER), "owner can MemberAt");
+
+            // After leave, former member loses live read on Drive history
+            drive.RemoveMember(member1);
+            vm.prank(member1);
+            vm.expectRevert();
+            drive.RoleAt(member1, block.timestamp);
+        } else {
+            // Non-Oasis: open read for any caller
+            vm.prank(stranger);
+            MembershipHistory.MembershipAtResult memory open = drive.RoleAt(member1, block.timestamp);
+            Assert.equal(uint256(open.status), uint256(STATUS_MEMBER), "non-oasis stranger can RoleAt");
+
+            vm.prank(stranger);
+            Assert.greaterThan(drive.MembershipHistoryStart(), uint256(0), "non-oasis stranger MembershipHistoryStart");
+
+            vm.prank(stranger);
+            MembershipHistory.MembershipAtResult memory openM = identity.MemberAt(device, block.timestamp);
+            Assert.equal(uint256(openM.status), uint256(STATUS_MEMBER), "non-oasis stranger can MemberAt");
+
+            vm.prank(stranger);
+            Assert.greaterThan(identity.MembershipHistoryStart(), uint256(0), "non-oasis stranger identity start");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Gate `RoleAt`, `MemberAt`, and `MembershipHistoryStart` with `onlyReader` on Drive / ProtectedRoleGroup (and DriveMember), matching live membership reads
- Fix Oasis `requireReader` from always-true `role >= None` to `role > None`; bump Drive to v162 and DriveMember to v125
- Document Oasis vs non-Oasis access in the membership history client spec; add diode/oasis tests and `make test-oasis` (`FOUNDRY_PROFILE=oasis`)

## Test plan
- [ ] `forge test --match-contract MembershipHistoryTest`
- [ ] `FOUNDRY_PROFILE=oasis forge test --match-contract MembershipHistoryTest` (or `make test-oasis`)
- [ ] Confirm non-Oasis builds still allow stranger eth_call for history views; Oasis denies without reader/whitelist


Made with [Cursor](https://cursor.com)